### PR TITLE
The fix to remove console errors about elements which are hidden

### DIFF
--- a/src/vue-parallax-js.js
+++ b/src/vue-parallax-js.js
@@ -22,6 +22,8 @@ parallaxjs.prototype = {
     let arg = binding.arg
     let style = el.currentStyle || window.getComputedStyle(el);
 
+    if (style.display === 'none') return
+
     let height = binding.modifiers.absY ? window.innerHeight : el.clientHeight || el.offsetHeight || el.scrollHeight;
     this.items.push({
       el: el,

--- a/vue-parallax-js.js
+++ b/vue-parallax-js.js
@@ -20,6 +20,8 @@ parallaxjs.prototype = {
     var arg = binding.arg;
     var style = el.currentStyle || window.getComputedStyle(el);
 
+    if (style.display === 'none') return;
+
     var height = binding.modifiers.absY ? window.innerHeight : el.clientHeight || el.offsetHeight || el.scrollHeight;
     this.items.push({
       el: el,
@@ -99,6 +101,17 @@ export default {
         p.add(el, binding);
         p.move(p);
       }
-    });
+    }
+    // unbind(el, binding) {
+    //   p.remove(el)
+    // }
+    // bind: parallaxjs.add(parallaxjs),
+    // update(value) {
+    //  parallaxjs.update(value)
+    // },
+    // update(el, binding) {
+    //   console.log("cup");
+    // },
+    );
   }
 };


### PR DESCRIPTION
A little fix to escape a problem with hidden (through display:none) items. If there are some hidden elements, the script sends a errors to console (it's about offsetParent as null)
http://joxi.ru/a2XGZoKTyKb1bm