### PR TITLE
Adding additional class name to parallaxing element

### DIFF
--- a/src/vue-parallax-js.js
+++ b/src/vue-parallax-js.js
@@ -24,6 +24,8 @@ parallaxjs.prototype = {
 
     if (style.display === 'none') return
 
+    el.classList.add('parallaxed')
+  
     let height = binding.modifiers.absY ? window.innerHeight : el.clientHeight || el.offsetHeight || el.scrollHeight;
     this.items.push({
       el: el,

--- a/vue-parallax-js.js
+++ b/vue-parallax-js.js
@@ -22,6 +22,8 @@ parallaxjs.prototype = {
 
     if (style.display === 'none') return;
 
+    el.classList.add('parallaxed');
+
     var height = binding.modifiers.absY ? window.innerHeight : el.clientHeight || el.offsetHeight || el.scrollHeight;
     this.items.push({
       el: el,


### PR DESCRIPTION
Hello :)
IMO, this will be helpful for accident situations when plugin is off and your elements have specific styles for parallax.
For example, your element without parallax should be at position {top: 10px} and with parallax - at {top: -10px}.